### PR TITLE
honor pelican DISPLAY_PAGES_ON_MENU setting

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -125,12 +125,14 @@
       {% block header %}
       <p id="header">
       <a href="{{ SITEURL }}">Home</a>
-      
+
+      {% if DISPLAY_PAGES_ON_MENU %}
       {% for p in pages %}
       {% if p.url != "index.html" %}
       &#124; <a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a>
       {% endif %}
       {% endfor %}
+      {% endif %}
       {% if INDEX_SAVE_AS and INDEX_SAVE_AS != "index.html" %}
       &#124; <a href="{{ SITEURL }}/{{ INDEX_SAVE_AS }}">Blog</a>
       {% endif %}


### PR DESCRIPTION
Simple change to honor existing Pelican setting. Default value is 'True', and pelican-subtle shows Pages in the menu by default, so I don't think this merge should affect any existing site's display choice.