### PR TITLE
add option to display date/author/tags above article, open sidebar links in new tabs

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -13,34 +13,18 @@
 
 {% block content %}
 <article>
+  {% if DISPLAY_META_ABOVE_ARTICLE %}
+    {% include "modules/article_meta.html" %}
+  {% endif %}
   <div class="article_title">
     <h1><a href="{{ SITEURL }}/{{ article.url }}" class="nohover">{{ article.title }}</a></h1>
   </div>
   <div class="article_text">
     {{ article.content }}
   </div>
-  <div class="article_meta">
-    <p>Posted <time data-timeago datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
-    {% if article.author %}
-     by {% if AUTHORS_URL %} <a href="{{ SITEURL }}/{{ article.author.url }}">{{ article.author }}</a>{% else %}{{ article.author}}{% endif %}
-    {% endif %}
-    </p>
-    {% if article.modified %}
-    <p>Last updated <time data-timeago datetime="{{ article.modified.isoformat() }}">{{ article.locale_modified }}</time></p>
-    {% endif %}
-    <p>
-    {% if CATEGORY_URL %}
-    Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
-    {% if TAG_URL and article.tags %}&ndash;&ndash;{% endif %}
-    {% endif %}
-    {% if TAG_URL and article.tags %}
-    Tags:
-      {% for tag in article.tags %}
-      <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
-      {% endfor %}
-    </p>
-    {% endif %}
-  </div>
+  {% if not DISPLAY_META_ABOVE_ARTICLE %}
+    {% include "modules/article_meta.html" %}
+  {% endif %}
 
   {% if DISQUS_SITENAME %}
   <div id="article_comments">

--- a/templates/base.html
+++ b/templates/base.html
@@ -91,9 +91,9 @@
 
 {%- macro display_link(name, link, text) -%}
   {%- if MANGLE_EMAILS and link.startswith('mailto:') -%}
-  <a data-email="{{ link|reverse }}"{% if not text %} data-title="{{ name }}"{% endif %} title="You need javascript enabled to view this email" class="email">{{ text }}{{ get_icon(link) }}</a>
+  <a data-email="{{ link|reverse }}"{% if not text %} data-title="{{ name }}"{% endif %} title="You need javascript enabled to view this email" class="email" rel="noopener noreferrer">{{ text }}{{ get_icon(link) }}</a>
   {%- else -%}
-  <a href="{{ link }}"{% if not text %} title="{{ name }}"{% endif %}>{{ text }}{{ get_icon(link) }}</a>
+  <a href="{{ link }}"{% if not text %} title="{{ name }}"{% endif %} target="_blank" rel="noopener noreferrer">{{ text }}{{ get_icon(link) }}</a>
   {%- endif -%}
 {%- endmacro -%}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -91,7 +91,7 @@
 
 {%- macro display_link(name, link, text) -%}
   {%- if MANGLE_EMAILS and link.startswith('mailto:') -%}
-  <a data-email="{{ link|reverse }}"{% if not text %} data-title="{{ name }}"{% endif %} title="You need javascript enabled to view this email" class="email" rel="noopener noreferrer">{{ text }}{{ get_icon(link) }}</a>
+  <a data-email="{{ link|reverse }}"{% if not text %} data-title="{{ name }}"{% endif %} title="You need javascript enabled to view this email" class="email" target="_blank" rel="noopener noreferrer">{{ text }}{{ get_icon(link) }}</a>
   {%- else -%}
   <a href="{{ link }}"{% if not text %} title="{{ name }}"{% endif %} target="_blank" rel="noopener noreferrer">{{ text }}{{ get_icon(link) }}</a>
   {%- endif -%}

--- a/templates/modules/article_meta.html
+++ b/templates/modules/article_meta.html
@@ -1,0 +1,22 @@
+<div class="article_meta">
+  <p>Posted <time data-timeago datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
+  {% if article.author %}
+   by {% if AUTHORS_URL %} <a href="{{ SITEURL }}/{{ article.author.url }}">{{ article.author }}</a>{% else %}{{ article.author}}{% endif %}
+  {% endif %}
+  </p>
+  {% if article.modified %}
+  <p>Last updated <time data-timeago datetime="{{ article.modified.isoformat() }}">{{ article.locale_modified }}</time></p>
+  {% endif %}
+  <p>
+  {% if CATEGORY_URL %}
+  Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
+  {% if TAG_URL and article.tags %}&ndash;&ndash;{% endif %}
+  {% endif %}
+  {% if TAG_URL and article.tags %}
+  Tags:
+    {% for tag in article.tags %}
+    <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
+    {% endfor %}
+  </p>
+  {% endif %}
+</div>


### PR DESCRIPTION
Nuked my old fork so remaking this PR, also added the `rel=` attribute to avoid security problems with `target=_blank`

Original PR comment:

Just a personal preference but I like seeing the publish date at the top of an article, gives me quick idea how stale the answer I'm looking for might be :)

This breaks the data classified as "article_meta" (publish date/tags/author/modified/categories) out into a module that can be displayed below the article content (default) or above via the DISPLAY_META_ABOVE_ARTICLE setting