### PR TITLE
update analytics code

### DIFF
--- a/templates/modules/analytics.html
+++ b/templates/modules/analytics.html
@@ -3,7 +3,7 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://ssl.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ GOOGLE_ANALYTICS_ID }}', '{{ GOOGLE_ANALYTICS_PROP }}');
   ga('send', 'pageview');


### PR DESCRIPTION
Looks like there was a domain change on the analytics code at some point, which you can verify [here](https://developers.google.com/analytics/devguides/collection/analyticsjs/)

The subdomain for analytics.html should be www.google-analytics.com now, not ssl.google-analytics.com . Using ssl instead of www causes google webmaster tools to fail to verify
